### PR TITLE
refactor: Make tailwindcss and nextjs into structs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,10 +2,7 @@ use clap::{Parser, Subcommand};
 
 use crate::backend::axum::Axum;
 use crate::docker::Dockerfile;
-use crate::frontend::{
-    css::{create_tailwindcss_files, setup_tailwind_config},
-    nextjs::create_nextjs_files,
-};
+use crate::frontend::nextjs::Nextjs;
 use crate::setup::Setup;
 use crate::utils::{run_command, PackageJson};
 
@@ -38,24 +35,7 @@ pub fn parse_commands() -> Result<(), String> {
         Cmd::Start => {
             let mut init_args = Setup::get_name();
 
-            SetupCmd::CreateNextApp.run(Some(&init_args.project_name), None);
-            SetupCmd::FrontendDeps.run(None, Some(&init_args.workdir));
-            SetupCmd::TailwindDeps.run(None, Some(&init_args.workdir));
-            SetupCmd::TailwindInit.run(None, Some(&init_args.workdir));
-            setup_tailwind_config(init_args.workdir.clone());
-
-            create_tailwindcss_files(init_args.workdir.clone())
-                .expect("Failed to make TailwindCSS files");
-            create_nextjs_files(init_args.workdir.clone()).expect("Failed to make NextJS files");
-
-            let mut packagejson_filepath = init_args.workdir.clone();
-
-            packagejson_filepath.push_str("/package.json");
-
-            PackageJson::from_json(&packagejson_filepath)
-                .add_data()
-                .write_to_file(&packagejson_filepath)
-                .expect("Failed to write to package.json");
+            Nextjs::bootstrap(init_args.clone());
 
             SetupCmd::CargoInit.run(Some("backend"), Some(&init_args.workdir));
 

--- a/src/frontend/css.rs
+++ b/src/frontend/css.rs
@@ -2,29 +2,34 @@ use std::fs;
 use std::io;
 use std::io::Write;
 
-pub fn create_tailwindcss_files(mut workdir: String) -> io::Result<()> {
-    workdir.push_str("/src/styles/");
+pub struct TailwindCSS;
 
-    fs::remove_dir_all(&workdir)?;
-    fs::create_dir(&workdir)?;
+impl TailwindCSS {
+    pub fn create_tailwindcss_files(mut workdir: String) -> io::Result<()> {
+        workdir.push_str("/src/styles/");
 
-    workdir.push_str("/globals.css");
+        fs::remove_dir_all(&workdir)?;
+        fs::create_dir(&workdir)?;
 
-    let mut f = fs::File::create(&workdir).expect("Failed to remake the global CSS file.");
+        workdir.push_str("/globals.css");
 
-    f.write_all(TAILWINDCSS_CSS_FILE.as_bytes())
-        .expect("Failed to fill the tailwindCSS file with text.");
+        let mut f = fs::File::create(&workdir).expect("Failed to remake the global CSS file.");
 
-    Ok(())
-}
+        f.write_all(TAILWINDCSS_CSS_FILE.as_bytes())
+            .expect("Failed to fill the tailwindCSS file with text.");
 
-pub fn setup_tailwind_config(mut workdir: String) {
-    workdir.push_str("/tailwind.config.js");
+        Ok(())
+    }
 
-    let mut f = fs::File::create(&workdir).expect("Failed to recreate the Tailwind config file");
+    pub fn setup_tailwind_config(mut workdir: String) {
+        workdir.push_str("/tailwind.config.js");
 
-    f.write_all(TAILWINDCSS_CONFIG_FILE.as_bytes())
-        .expect("Failed to fill the tailwind config file :(");
+        let mut f =
+            fs::File::create(&workdir).expect("Failed to recreate the Tailwind config file");
+
+        f.write_all(TAILWINDCSS_CONFIG_FILE.as_bytes())
+            .expect("Failed to fill the tailwind config file :(");
+    }
 }
 
 const TAILWINDCSS_CSS_FILE: &str = r#"@tailwind base;

--- a/src/frontend/nextjs.rs
+++ b/src/frontend/nextjs.rs
@@ -2,20 +2,63 @@ use std::fs;
 use std::io;
 use std::io::Write;
 
-pub fn create_nextjs_files(mut workdir: String) -> io::Result<()> {
-    let mut dir_to_delete = workdir.clone();
+use crate::commands::SetupCmd;
+use crate::frontend::css::TailwindCSS;
+use crate::setup::InitArgs;
+use crate::utils::PackageJson;
 
-    dir_to_delete.push_str("/src/pages/api");
+pub struct Nextjs;
 
-    fs::remove_dir_all(&dir_to_delete).expect("Failed to delete the default Next.js API folder");
+impl Nextjs {
+    pub fn bootstrap(init_args: InitArgs) {
+        SetupCmd::CreateNextApp.run(Some(&init_args.project_name), None);
+        SetupCmd::FrontendDeps.run(None, Some(&init_args.workdir));
+        SetupCmd::TailwindDeps.run(None, Some(&init_args.workdir));
+        SetupCmd::TailwindInit.run(None, Some(&init_args.workdir));
+        TailwindCSS::setup_tailwind_config(init_args.workdir.clone());
 
-    workdir.push_str("/src/pages/index.tsx");
+        TailwindCSS::create_tailwindcss_files(init_args.workdir.clone())
+            .expect("Failed to make TailwindCSS files");
+        Nextjs::create_page_files(init_args.workdir.clone()).expect("Failed to make NextJS files");
+        Nextjs::create_config_file(init_args.workdir.clone())
+            .expect("Failed to set up the nextjs config file");
 
-    let mut f = fs::File::create(&workdir).expect("Failed to recreate the index file");
+        let mut packagejson_filepath = init_args.workdir;
 
-    f.write_all(NEXTJS_HOMEPAGE_FILE.as_bytes())?;
+        packagejson_filepath.push_str("/package.json");
 
-    Ok(())
+        PackageJson::from_json(&packagejson_filepath)
+            .add_data()
+            .write_to_file(&packagejson_filepath)
+            .expect("Failed to write to package.json");
+    }
+
+    pub fn create_page_files(mut workdir: String) -> io::Result<()> {
+        let mut dir_to_delete = workdir.clone();
+
+        dir_to_delete.push_str("/src/pages/api");
+
+        fs::remove_dir_all(&dir_to_delete)
+            .expect("Failed to delete the default Next.js API folder");
+
+        workdir.push_str("/src/pages/index.tsx");
+
+        let mut f = fs::File::create(&workdir).expect("Failed to recreate the index file");
+
+        f.write_all(NEXTJS_HOMEPAGE_FILE.as_bytes())?;
+
+        Ok(())
+    }
+
+    pub fn create_config_file(mut workdir: String) -> io::Result<()> {
+        workdir.push_str("/next.config.js");
+
+        let mut f = fs::File::create(&workdir).expect("Couldn't remake the next.config.js file :(");
+
+        f.write_all(NEXTJS_CONFIG_FILE.as_bytes())?;
+
+        Ok(())
+    }
 }
 
 const NEXTJS_HOMEPAGE_FILE: &str = r#"import Head from 'next/head'
@@ -53,3 +96,12 @@ export default function Home() {
     </>
   )
 }"#;
+
+const NEXTJS_CONFIG_FILE: &str = r#"/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  trailingSlash: true,
+}
+
+module.exports = nextConfig
+"#;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -21,6 +21,7 @@ impl Setup {
     }
 }
 
+#[derive(Clone)]
 pub struct InitArgs {
     pub project_name: String,
     pub workdir: String,


### PR DESCRIPTION
* Make Nextjs functions part of a Nextjs struct.
* Add a function to make the `next.config.js` file have the trailingSlash property.
* Make TailwindCSS functions part of a TailwindCSS struct.
